### PR TITLE
Load username and password from pianobar config without prompting.

### DIFF
--- a/README
+++ b/README
@@ -58,6 +58,9 @@ the number used to select the station you want through Pianobar.
 If you leave any of these unset, you will be prompted for the info
 instead.
 
+If your pianobar config contains your username and password, you can
+set `(setq pianobar-config t)`.
+
 If you set `pianobar-run-in-background` to `t`, `M-x pianobar` will
 *not* show the `*pianobar*` buffer after running. This is useful if
 you set the above auto-login variables.


### PR DESCRIPTION
Pianobar config supports username and (encrypted) password. This adds a `pianobar-config' boolean variable to disable prompting, and avoid writing to and blocking the comint input buffer from running additional commands.
