### PR TITLE
WIP: Introduce EIEIO

### DIFF
--- a/pianobar.el
+++ b/pianobar.el
@@ -59,6 +59,7 @@
 
 (require 'comint)
 (require 'subr-x)
+(require 'eieio)
 
 (defvar pianobar-buffer
   "*pianobar*"
@@ -113,6 +114,9 @@ or nil to let you select.")
   "\\[\\?\\] .*: $"
   "A regex for matching a pianobar prompt.")
 
+(defvar pianobar-songs '()
+  "A list of all pianobar songs played this session.")
+
 (defvar pianobar-current-station nil
   "The current pianobar station, or nil.")
 
@@ -124,6 +128,21 @@ or nil to let you select.")
 
 (defvar pianobar-current-artist nil
   "The current pianobar artist, or nil.")
+
+(defclass pianobar-song ()              ; No superclasses
+  ((name :initarg :name
+         :initform ""
+         :type string
+         :documentation "The name of the song")
+   (artist :initarg :artist
+           :initform ""
+           :type string
+           :documentation "The song's recording artist")
+   (album :initarg :album
+          :initform ""
+          :type string
+          :documentation "The album the song is from"))
+  "A class for Pianobar songs")
 
 (defvar pianobar-info-extract-rules
   '(("|> +Station \"\\(.+\\)\" +([0-9]*)$" (1 . pianobar-current-station))
@@ -197,7 +216,7 @@ in favor of pianobar-enable-modeline.")
     (if (string-match (car rule) str)
         (dolist (symbol-map (cdr rule))
           (set (cdr symbol-map) (match-string (car symbol-map) str)))))
-
+  (push (pianobar-song :name pianobar-current-song :artist pianobar-current-artist :album pianobar-current-album) pianobar-songs)
   (pianobar-update-modeline))
 
 (defun pianobar-send-command (char &optional set-active)
@@ -238,7 +257,7 @@ Returns t on success, nil on error."
   "Tell pianobar to shelve  the current song for a month (tired)."
   (interactive)
   (if (and pianobar-current-song (pianobar-send-command ?t))
-	  (message (concat "Pianobar: Shelved " pianobar-current-song))))
+    (message (concat "Pianobar: Shelved " pianobar-current-song))))
 
 (defun pianobar-volume-up ()
   "Tell pianobar increase the volume."

--- a/pianobar.el
+++ b/pianobar.el
@@ -216,6 +216,7 @@ in favor of pianobar-enable-modeline.")
     (if (string-match (car rule) str)
         (dolist (symbol-map (cdr rule))
           (set (cdr symbol-map) (match-string (car symbol-map) str)))))
+
   (pianobar-update-modeline))
 
 (defun pianobar-send-command (char &optional set-active)

--- a/pianobar.el
+++ b/pianobar.el
@@ -129,7 +129,7 @@ or nil to let you select.")
 (defvar pianobar-current-artist nil
   "The current pianobar artist, or nil.")
 
-(defclass pianobar-song ()              ; No superclasses
+(defclass pianobar-song ()
   ((name :initarg :name
          :initform ""
          :type string

--- a/pianobar.el
+++ b/pianobar.el
@@ -216,7 +216,6 @@ in favor of pianobar-enable-modeline.")
     (if (string-match (car rule) str)
         (dolist (symbol-map (cdr rule))
           (set (cdr symbol-map) (match-string (car symbol-map) str)))))
-  (push (pianobar-song :name pianobar-current-song :artist pianobar-current-artist :album pianobar-current-album) pianobar-songs)
   (pianobar-update-modeline))
 
 (defun pianobar-send-command (char &optional set-active)


### PR DESCRIPTION
Hey, although I've had `pianobar.el` installed for years, I've only started using it hardcore recently. Pandora + Emacs is really the perfect "hands off" music experience. I also think it's fun to hack on music players.

I have an idea: how do you feel about us introducing [EIEIO](https://www.gnu.org/software/emacs/manual/html_mono/eieio.html) so that we can start tracking previous songs, and allowing actions on previous songs?

Once we have a list of previous songs as objects, we can start hacking on a cooler user interface too.

The other way we could do this is alists or plists, but I would really like to use object methods like "love" or "ban" or "shelve" to create a more hackable interface.

If this EIEIO idea looks good to you, I can go ahead and find the best  place to add the push:
```
(push (pianobar-song :name pianobar-current-song :artist pianobar-current-artist :album pianobar-current-album) pianobar-songs)
```